### PR TITLE
add default required review count

### DIFF
--- a/src/_modules/repository/branch_protection.tf
+++ b/src/_modules/repository/branch_protection.tf
@@ -6,5 +6,7 @@ resource "github_branch_protection" "main" {
   allows_deletions        = false
   required_linear_history = true
 
-  required_pull_request_reviews {}
+  required_pull_request_reviews {
+    required_approving_review_count = var.required_approving_review_count != null ? var.required_approving_review_count : 0
+  }
 }

--- a/src/_modules/repository/variables.tf
+++ b/src/_modules/repository/variables.tf
@@ -68,3 +68,9 @@ variable "actions" {
     error_message = "The secret name cannot start with 'GITHUB_'."
   }
 }
+
+variable "required_approving_review_count" {
+  type        = number
+  description = "The required approving review count of the repository"
+  default     = 0
+}


### PR DESCRIPTION
As Im currently working on my own projects it's not really handy to require a separate reviewer besides myself. So for now we just default the required reviewers to 0 (This can be changed on a repo-by-repo basis)