### PR TITLE
patch: configure renovate

### DIFF
--- a/renovate5.json
+++ b/renovate5.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "platform": "github",
+  "semanticCommits": "enabled",
+  "labels": [
+    "renovate"
+  ],
+  "repositories": [
+    "dc-tec/github-config"
+  ],
+  "terraform": {
+    "fileMatch": [
+      "\\.tf$"
+    ]
+  },
+  "extends": [
+    "config:recommended"
+  ]
+}


### PR DESCRIPTION
Configured the Github action, but never configured renovate itself. This is fixed now